### PR TITLE
Fix issue when [V4+ Styles] section is after [Events]

### DIFF
--- a/unlinkmkv
+++ b/unlinkmkv
@@ -820,7 +820,9 @@ use File::Spec::Functions;
       while (my $line = <$F>) {
 
         if($line =~ /^\[/ && $line =~ /^\[V4\+ Styles/) {
-          $in = 1;
+          $in  = 1;
+          $di  = 0;
+          $key = undef;
         }
         elsif(($in || $di)&& !defined $key && $line =~ /^Format:/i) {
           my $test = "$line";


### PR DESCRIPTION
I came across some files whose `[V4+ Styles]` section was after the `[Events]` section, causing the unique id to be printed in the `SecondaryColour` field:

Before:
```
Style: MOBILE SUIT,Serpentine-Bold-Bold,30,&H002D8AC3 u2301830336,&H000000FF,&H00000000,&H00000000,0,-1,0,0,100,100,3,0,1,2,0,2,10,10,10,1
```

After:
```
Style: MOBILE SUIT u2301830336,Serpentine-Bold-Bold,30,&H002D8AC3,&H000000FF,&H00000000,&H00000000,0,-1,0,0,100,100,3,0,1,2,0,2,10,10,10,1
```
