### PR TITLE
Update README.MD to clarify JSON is needed

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -97,6 +97,7 @@ This script requires:
    XML::LibXML >= 2.0001
    IPC::Run3
    File::Which
+   JSON
    String::CRC32
    Log::Log4perl
    Math::BigFloat


### PR DESCRIPTION
On Arch specifically, `perl-json`, it may be others on other platforms.